### PR TITLE
undefined % 4 > 0 is always false :)

### DIFF
--- a/lib/b64.js
+++ b/lib/b64.js
@@ -6,7 +6,7 @@
 	function b64ToByteArray(b64) {
 		var i, l, tmp, hasPadding, arr = [];
 
-		if (i % 4 > 0) {
+		if (b64.length % 4 > 0) {
 			throw 'Invalid string. Length must be a multiple of 4';
 		}
 


### PR DESCRIPTION
`i` is undefined and `undefined % 4 > 0` is always false so this code will never throw an error, no matter how long will be the string.

``` js
var i, l, tmp, hasPadding, arr = [];

if (i % 4 > 0) {
       throw 'Invalid string. Length must be a multiple of 4';
}
```

Regards,
Satanowski
