### PR TITLE
make decoding base64 10x faster

### DIFF
--- a/lib/b64.js
+++ b/lib/b64.js
@@ -2,122 +2,122 @@ var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
 
 ;(function (exports) {
-  'use strict';
+	'use strict';
 
-  var ZERO   = '0'.charCodeAt(0)
-  var PLUS   = '+'.charCodeAt(0)
-  var SLASH  = '/'.charCodeAt(0)
-  var NUMBER = '0'.charCodeAt(0)
-  var LOWER  = 'a'.charCodeAt(0)
-  var UPPER  = 'A'.charCodeAt(0)
+	var ZERO   = '0'.charCodeAt(0)
+	var PLUS   = '+'.charCodeAt(0)
+	var SLASH  = '/'.charCodeAt(0)
+	var NUMBER = '0'.charCodeAt(0)
+	var LOWER  = 'a'.charCodeAt(0)
+	var UPPER  = 'A'.charCodeAt(0)
 
-  function decode (elt) {
-    var code = elt.charCodeAt(0)
-    if(code === PLUS)
-      return 62 // '+'
-    if(code === SLASH)
-      return 63 // '/'
-    if(code < NUMBER)
-      return -1 //no match
-    if(code < NUMBER + 10)
-      return code - NUMBER + 26 + 26
-    if(code < UPPER + 26)
-      return code - UPPER
-    if(code < LOWER + 26)
-      return code - LOWER + 26
-  }
+	function decode (elt) {
+		var code = elt.charCodeAt(0)
+		if(code === PLUS)
+			return 62 // '+'
+		if(code === SLASH)
+			return 63 // '/'
+		if(code < NUMBER)
+			return -1 //no match
+		if(code < NUMBER + 10)
+			return code - NUMBER + 26 + 26
+		if(code < UPPER + 26)
+			return code - UPPER
+		if(code < LOWER + 26)
+			return code - LOWER + 26
+	}
 
-  function b64ToByteArray(b64) {
-    var i, j, l, tmp, placeHolders, arr;
-  
-    if (b64.length % 4 > 0) {
-      throw 'Invalid string. Length must be a multiple of 4';
-    }
+	function b64ToByteArray(b64) {
+		var i, j, l, tmp, placeHolders, arr;
+	
+		if (b64.length % 4 > 0) {
+			throw 'Invalid string. Length must be a multiple of 4';
+		}
 
-    // the number of equal signs (place holders)
-    // if there are two placeholders, than the two characters before it
-    // represent one byte
-    // if there is only one, then the three characters before it represent 2 bytes
-    // this is just a cheap hack to not do indexOf twice
-    var len = b64.length
-    placeHolders = '=' === b64[len - 2] ? 2 : '=' === b64[len - 1] ? 1 : 0
+		// the number of equal signs (place holders)
+		// if there are two placeholders, than the two characters before it
+		// represent one byte
+		// if there is only one, then the three characters before it represent 2 bytes
+		// this is just a cheap hack to not do indexOf twice
+		var len = b64.length
+		placeHolders = '=' === b64[len - 2] ? 2 : '=' === b64[len - 1] ? 1 : 0
 
-    // base64 is 4/3 + up to two characters of the original data
-    arr = new Uint8Array(b64.length * 3 / 4 - placeHolders);
+		// base64 is 4/3 + up to two characters of the original data
+		arr = new Uint8Array(b64.length * 3 / 4 - placeHolders);
 
-    // if there are placeholders, only get up to the last complete 4 chars
+		// if there are placeholders, only get up to the last complete 4 chars
 
 
 
-    l = placeHolders > 0 ? b64.length - 4 : b64.length;
+		l = placeHolders > 0 ? b64.length - 4 : b64.length;
 
-    var L = 0
+		var L = 0
 
-    function push (v) {
-      arr[L++] = v
-    }
+		function push (v) {
+			arr[L++] = v
+		}
 
-    for (i = 0, j = 0; i < l; i += 4, j += 3) {
-      tmp = (decode(b64.charAt(i)) << 18) | (decode(b64.charAt(i + 1)) << 12) | (decode(b64.charAt(i + 2)) << 6) | decode(b64.charAt(i + 3));
-      push((tmp & 0xFF0000) >> 16);
-      push((tmp & 0xFF00) >> 8);
-      push(tmp & 0xFF);
-    }
+		for (i = 0, j = 0; i < l; i += 4, j += 3) {
+			tmp = (decode(b64.charAt(i)) << 18) | (decode(b64.charAt(i + 1)) << 12) | (decode(b64.charAt(i + 2)) << 6) | decode(b64.charAt(i + 3));
+			push((tmp & 0xFF0000) >> 16);
+			push((tmp & 0xFF00) >> 8);
+			push(tmp & 0xFF);
+		}
 
-    if (placeHolders === 2) {
-      tmp = (decode(b64.charAt(i)) << 2) | (decode(b64.charAt(i + 1)) >> 4);
-      push(tmp & 0xFF);
-    } else if (placeHolders === 1) {
-      tmp = (decode(b64.charAt(i)) << 10) | (decode(b64.charAt(i + 1)) << 4) | (decode(b64.charAt(i + 2)) >> 2);
-      push((tmp >> 8) & 0xFF);
-      push(tmp & 0xFF);
-    }
+		if (placeHolders === 2) {
+			tmp = (decode(b64.charAt(i)) << 2) | (decode(b64.charAt(i + 1)) >> 4);
+			push(tmp & 0xFF);
+		} else if (placeHolders === 1) {
+			tmp = (decode(b64.charAt(i)) << 10) | (decode(b64.charAt(i + 1)) << 4) | (decode(b64.charAt(i + 2)) >> 2);
+			push((tmp >> 8) & 0xFF);
+			push(tmp & 0xFF);
+		}
 
-    return arr;
-  }
+		return arr;
+	}
 
-  function uint8ToBase64(uint8) {
-    var i,
-      extraBytes = uint8.length % 3, // if we have 1 byte left, pad 2 bytes
-      output = "",
-      temp, length;
+	function uint8ToBase64(uint8) {
+		var i,
+			extraBytes = uint8.length % 3, // if we have 1 byte left, pad 2 bytes
+			output = "",
+			temp, length;
 
-    function encode (num) {
-      return lookup.charAt(num)
-    }
+		function encode (num) {
+			return lookup.charAt(num)
+		}
 
-    function tripletToBase64 (num) {
-      return encode(num >> 18 & 0x3F) + encode(num >> 12 & 0x3F) + encode(num >> 6 & 0x3F) + encode(num & 0x3F);
-    };
+		function tripletToBase64 (num) {
+			return encode(num >> 18 & 0x3F) + encode(num >> 12 & 0x3F) + encode(num >> 6 & 0x3F) + encode(num & 0x3F);
+		};
 
-    // go through the array every three bytes, we'll deal with trailing stuff later
-    for (i = 0, length = uint8.length - extraBytes; i < length; i += 3) {
-      temp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2]);
-      output += tripletToBase64(temp);
-    }
+		// go through the array every three bytes, we'll deal with trailing stuff later
+		for (i = 0, length = uint8.length - extraBytes; i < length; i += 3) {
+			temp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2]);
+			output += tripletToBase64(temp);
+		}
 
-    // pad the end with zeros, but make sure to not forget the extra bytes
-    switch (extraBytes) {
-      case 1:
-        temp = uint8[uint8.length - 1];
-        output += encode(temp >> 2);
-        output += encode((temp << 4) & 0x3F);
-        output += '==';
-        break;
-      case 2:
-        temp = (uint8[uint8.length - 2] << 8) + (uint8[uint8.length - 1]);
-        output += encode(temp >> 10);
-        output += encode((temp >> 4) & 0x3F);
-        output += encode((temp << 2) & 0x3F);
-        output += '=';
-        break;
-    }
+		// pad the end with zeros, but make sure to not forget the extra bytes
+		switch (extraBytes) {
+			case 1:
+				temp = uint8[uint8.length - 1];
+				output += encode(temp >> 2);
+				output += encode((temp << 4) & 0x3F);
+				output += '==';
+				break;
+			case 2:
+				temp = (uint8[uint8.length - 2] << 8) + (uint8[uint8.length - 1]);
+				output += encode(temp >> 10);
+				output += encode((temp >> 4) & 0x3F);
+				output += encode((temp << 2) & 0x3F);
+				output += '=';
+				break;
+		}
 
-    return output;
-  }
+		return output;
+	}
 
-  module.exports.toByteArray = b64ToByteArray;
-  module.exports.fromByteArray = uint8ToBase64;
-  module.exports.lookup = lookup
+	module.exports.toByteArray = b64ToByteArray;
+	module.exports.fromByteArray = uint8ToBase64;
+	module.exports.lookup = lookup
 }());
 

--- a/test/bench.js
+++ b/test/bench.js
@@ -13,7 +13,7 @@ var end = Date.now()
 
 console.log('decode ms, decode ops/ms, encode ms, encode ops/ms')
 console.log(
-  middle - start,  data.length / (middle - start), 
-  end - middle,  data.length / (end - middle))
+	middle - start,  data.length / (middle - start), 
+	end - middle,  data.length / (end - middle))
 //console.log(data)
 


### PR DESCRIPTION
this pull request makes decoding base64 much much faster.
the trick was to use a hard coded offsets and comparisons and toCharCode
to compute the value for a character, instead of searching for that character in a table.

results, on a 100k random value,
note (on `{de,en}code ms` columns, lower is better, but on `ops/ms` colums, higher is better.

```
[dominic@COMPUTER base64-js]$ git checkout f617396dabd1dab18a069de7a48acbdc95498c09
HEAD is now at f617396... simple script to measure time to decode/encode
[dominic@COMPUTER base64-js]$ node test/bench.js 
decode ms, decode ops/ms, encode ms, encode ops/ms
494 2699.0607287449393 91 14652.043956043955
[dominic@COMPUTER base64-js]$ git checkout 96c7a98bfb5c4ac10f30d60920e2ce8fc7c24b41
HEAD is now at 96c7a98... base64-js uses tabs, sorry!
[dominic@COMPUTER base64-js]$ node test/bench.js 
decode ms, decode ops/ms, encode ms, encode ops/ms
41 32520.39024390244 80 16666.7
```

There also seems to be a 10% improvement in encode perf, not sure what that is from.

Okay, so the one thing, is that this switches to `Uint8Array`, so we need to discuss the best way to
both support old browsers and to enable the perf improvement that TypedArrays allow.
Maybe the answer is just to use @substack's typedarray polyfil? 
Also there is @feross's https://github.com/feross/native-buffer-browserify
but i'd like to compare that against raw typedarrays for a real world use case
(I have one here: github.com/dominictarr/sha.js before commiting to anything)
