### PR TITLE
This pull request fixes some lint warnings.

### DIFF
--- a/lib/b64.js
+++ b/lib/b64.js
@@ -7,7 +7,6 @@ var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
     ? Uint8Array
     : Array
 
-	var ZERO   = '0'.charCodeAt(0)
 	var PLUS   = '+'.charCodeAt(0)
 	var SLASH  = '/'.charCodeAt(0)
 	var NUMBER = '0'.charCodeAt(0)
@@ -116,6 +115,6 @@ var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 		return output
 	}
 
-	module.exports.toByteArray = b64ToByteArray
-	module.exports.fromByteArray = uint8ToBase64
-}())
+	exports.toByteArray = b64ToByteArray
+	exports.fromByteArray = uint8ToBase64
+}(typeof exports === 'undefined' ? (this.base64js = {}) : exports))

--- a/test/convert.js
+++ b/test/convert.js
@@ -10,8 +10,7 @@ var test = require('tape'),
 		'sup',
 		'sup?',
 		'sup?!'
-	],
-	res;
+	];
 
 test('convert to base64 and back', function (t) {
   t.plan(checks.length);


### PR DESCRIPTION
JSHint, UglifyJs and other tools capable of linting complaining about some unused, but declared variables. This pull request gets rid of these.

Note: Fixing the `exports` issue that way allows one to use `lib/b64.js` natively in browsers, e.g.:

``` html
<script src="https://raw.githubusercontent.com/beatgammit/base64-js/master/lib/b64.js"></script>
<script>
  var base64string = base64js.fromByteArray(...);
  var bytes = base64js.toByteArray(...);
</script>
```
