### PR TITLE
Add back bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "base64-js",
+  "description": "Base64 encoding/decoding in pure JS",
+  "keywords": [
+    "base64"
+  ],
+  "homepage": "https://github.com/beatgammit/base64-js",
+  "license": "MIT",
+  "authors": [
+    "T. Jameson Little <t.jameson.little@gmail.com>"
+  ],
+  "moduleType": [
+    "globals",
+    "amd",
+    "node"
+  ],
+  "main": "base64js.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/beatgammit/base64-js.git"
+  },
+  "ignore": [
+    "/.*",
+    "bench",
+    "test"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "files": [
     "test",
     "index.js",
+    "base64js.js",
     "base64js.min.js"
   ],
   "main": "index.js",
@@ -22,7 +23,7 @@
     "url": "git://github.com/beatgammit/base64-js.git"
   },
   "scripts": {
-    "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+    "build": "browserify -s base64js -r ./ > base64js.js && uglifyjs -m < base64js.js > base64js.min.js",
     "lint": "standard",
     "test": "npm run lint && npm run unit",
     "unit": "tape test/*.js"


### PR DESCRIPTION
This allows to use base64-js as a dependency in other bower packages and have it load the right javascript file without using overrides.