### PR TITLE
Fixed correct operation when input is negative

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function encodeChunk (uint8, start, end) {
   var tmp
   var output = []
   for (var i = start; i < end; i += 3) {
-    tmp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+    tmp = ((uint8[i] << 16) & 0xFF0000) + ((uint8[i + 1] << 8) & 0xFF00) + (uint8[i + 2] & 0xFF)
     output.push(tripletToBase64(tmp))
   }
   return output.join('')

--- a/test/convert.js
+++ b/test/convert.js
@@ -29,6 +29,44 @@ test('convert to base64 and back', function (t) {
   }
 })
 
+var data = [
+    [[0, 0, 0], 'AAAA'],
+    [[0, 0, 1], 'AAAB'],
+    [[0, 1, -1], 'AAH/'],
+    [[1, 1, 1], 'AQEB'],
+    [[0, -73, 23], 'ALcX']
+]
+
+test('convert known data to string', function (t) {
+  for (var i = 0; i < data.length; i++) {
+    var bytes = data[i][0]
+    var expected = data[i][1]
+    var actual = b64.fromByteArray(bytes)
+    t.equal(actual, expected, 'Ensure that ' + bytes + ' serialise to ' + expected)
+  }
+  t.end()
+})
+
+test('convert known data from string', function (t) {
+  for (var i = 0; i < data.length; i++) {
+    var expected = data[i][0]
+    var string = data[i][1]
+    var actual = b64.toByteArray(string)
+    t.ok(equal(actual, expected), 'Ensure that ' + string + ' deserialise to ' + expected)
+  }
+  t.end()
+})
+
+function equal (a, b) {
+  var i
+  var length = a.length
+  if (length !== b.length) return false
+  for (i = 0; i < length; ++i) {
+    if ((a[i] & 0xFF) !== (b[i] & 0xFF)) return false
+  }
+  return true
+}
+
 function map (arr, callback) {
   var res = []
   var kValue, mappedValue


### PR DESCRIPTION
The two integers -1 and 255 represent the same byte (0xFF),
but the code would handle -1 incorrectly because input numbers
weren't properly masked so negative integers would case the
combining step in encodeChunk to produce the wrong triplet.

As an example, the triplet [0, -73, 23]  - [0x00, 0xB7, 0x17])
would combine into the integer -18665 (0xFFFFB717) instead of
the expected 46871 (0x0000B717).

This is fixed by correctly masking input values before combining
them into an integer.

This fixes #38 