### PR TITLE
Add support for encoding URL-safe base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,21 @@ For use in web browsers do:
 
 ## methods
 
-`base64js` has three exposed functions, `byteLength`, `toByteArray` and `fromByteArray`, which both take a single argument.
+`base64js` has three exposed functions, `byteLength`, `toByteArray` and `fromByteArray`, each requiring a single argument. `toByteArray` and `fromByteArray` also accept an optional `alphabet` argument (see `alphabets` property below).
 
 * `byteLength` - Takes a base64 string and returns length of byte array
 * `toByteArray` - Takes a base64 string and returns a byte array
 * `fromByteArray` - Takes a byte array and returns a base64 string
+
+## properties
+
+Use the `alphabets` property to do base64 transcoding with arbitrary alphabets. The included [base64url](https://tools.ietf.org/html/rfc4648#section-5) alphabet is implemented internally using this interface. Example:
+```
+b64.alphabets.custom = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?'
+var a = b64.toByteArray('aa+/')
+var b = b64.fromByteArray(a, 'custom')
+console.log(b === 'aa!?') // true
+```
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For use in web browsers do:
 
 ## properties
 
-Use the `alphabets` property to do base64 transcoding with arbitrary alphabets. The included [base64url](https://tools.ietf.org/html/rfc4648#section-5) alphabet is implemented internally using this interface. Example:
+Use the `alphabets` property to do base64 transcoding with arbitrary alphabets. The included [url](https://tools.ietf.org/html/rfc4648#section-5) alphabet is implemented internally using this interface. Example:
 ```
 b64.alphabets.custom = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?'
 var a = b64.toByteArray('aa+/')

--- a/index.js
+++ b/index.js
@@ -4,23 +4,23 @@ exports.byteLength = byteLength
 exports.toByteArray = toByteArray
 exports.fromByteArray = fromByteArray
 
-var lookups = { _: [], url: [] }
-var revLookups = { _: [], url: null }
+var lookups = { default: [], url: [] }
+var revLookups = { default: [], url: null }
 var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
 
 var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 for (var i = 0, len = code.length; i < len; ++i) {
-  lookups._[i] = lookups.url[i] = code[i]
-  revLookups._[code.charCodeAt(i)] = i
+  lookups.default[i] = lookups.url[i] = code[i]
+  revLookups.default[code.charCodeAt(i)] = i
 }
 
 // Support decoding URL-safe base64 strings, as Node.js does.
 // See: https://en.wikipedia.org/wiki/Base64#URL_applications
 lookups.url[62] = '-'
 lookups.url[63] = '_'
-revLookups._['-'.charCodeAt(0)] = 62
-revLookups._['_'.charCodeAt(0)] = 63
-revLookups.url = revLookups._
+revLookups.default['-'.charCodeAt(0)] = 62
+revLookups.default['_'.charCodeAt(0)] = 63
+revLookups.url = revLookups.default
 
 function getLens (b64) {
   var len = b64.length
@@ -58,7 +58,7 @@ function toByteArray (b64, alphabet) {
   var lens = getLens(b64)
   var validLen = lens[0]
   var placeHoldersLen = lens[1]
-  var revLookup = revLookups[alphabet || '_']
+  var revLookup = revLookups[alphabet || 'default']
 
   var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
 
@@ -126,7 +126,7 @@ function fromByteArray (uint8, alphabet) {
   var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
   var parts = []
   var maxChunkLength = 16383 // must be multiple of 3
-  var lookup = lookups[alphabet || '_']
+  var lookup = lookups[alphabet || 'default']
 
   // go through the array every three bytes, we'll deal with trailing stuff later
   for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {

--- a/test/alphabets.js
+++ b/test/alphabets.js
@@ -1,0 +1,19 @@
+var test = require('tape')
+var b64 = require('../')
+
+test('unknown alphabet', function (t) {
+  try {
+    b64.fromByteArray([], 'bogus')
+  } catch (err) {
+    t.equal(err.message, 'Unknown alphabet bogus')
+    t.end()
+  }
+})
+
+test('custom alphabets', function (t) {
+  b64.alphabets.custom = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?'
+  var a = b64.toByteArray('aa+/')
+  var b = b64.fromByteArray(a, 'custom')
+  t.deepEqual(b, 'aa!?')
+  t.end()
+})

--- a/test/url-safe.js
+++ b/test/url-safe.js
@@ -22,3 +22,15 @@ test('decode url-safe style base64 strings', function (t) {
 
   t.end()
 })
+
+test('encode url-safe style base64 strings', function (t) {
+  var expected = '__--_--_--__'
+
+  var bytes = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff]
+  var actual = b64.fromByteArray(bytes, 'url')
+  for (var i = 0; i < actual.length; i++) {
+    t.equal(actual[i], expected[i])
+  }
+
+  t.end()
+})

--- a/test/url-safe.js
+++ b/test/url-safe.js
@@ -1,7 +1,7 @@
 var test = require('tape')
 var b64 = require('../')
 
-test('decode url-safe style base64 strings', function (t) {
+test('default alphabet should also decode url-safe style base64 strings', function (t) {
   var expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff]
 
   var str = '//++/++/++//'
@@ -23,14 +23,18 @@ test('decode url-safe style base64 strings', function (t) {
   t.end()
 })
 
-test('encode url-safe style base64 strings', function (t) {
-  var expected = '__--_--_--__'
+test('decode base64url', function (t) {
+  t.deepEqual(
+    b64.toByteArray('--__', 'url'),
+    [251, 239, 255]
+  )
+  t.end()
+})
 
-  var bytes = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff]
-  var actual = b64.fromByteArray(bytes, 'url')
-  for (var i = 0; i < actual.length; i++) {
-    t.equal(actual[i], expected[i])
-  }
-
+test('decode base64url', function (t) {
+  t.deepEqual(
+    b64.fromByteArray([251, 239, 255], 'url'),
+    '--__'
+  )
   t.end()
 })

--- a/test/url-safe.js
+++ b/test/url-safe.js
@@ -31,7 +31,7 @@ test('decode base64url', function (t) {
   t.end()
 })
 
-test('decode base64url', function (t) {
+test('encode base64url', function (t) {
   t.deepEqual(
     b64.fromByteArray([251, 239, 255], 'url'),
     '--__'


### PR DESCRIPTION
There are a bunch of modules on npm that do this already, but it seems like most of them depend on another module (sometimes buffer itself) and then add regex replace or similar, or include lots of features I don't want. Since we already do decoding here, I figure adding encoding just makes things symmetrical and so doesn't feel too out of place.

Note that performance remains the same with this approach but there is a tiny memory penalty (the extra alphabet itself should only be another ~128 bytes?). Ideas for other approaches or references to alternate modules welcome.