### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,19 @@ node_js:
   - '10'
   - '12'
   - '14'
+arch:
+  - amd64
+  - ppc64le
 env:
   matrix:
     - TEST_SUITE=unit
 matrix:
   include:
     - os: linux
+      node_js: lts/*
+      env: TEST_SUITE=lint
+    - os: linux
+      arch: ppc64le
       node_js: lts/*
       env: TEST_SUITE=lint
 script: npm run $TEST_SUITE


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/base64-js/builds/209330095

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj