### PR TITLE
Use 'files' field in package instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.travis.yml
-bench/
-test/

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "files": [
+    "base64js.min.js",
+    "index.d.ts",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/beatgammit/base64-js.git"


### PR DESCRIPTION
Uses the [`files`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) field to describe which files need to be included in the package explicitly. This prevents files from accidentally slipping into the package as they are added to the repository.