### PR TITLE
Update 'tape' dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "benchmark": "^2.1.4",
     "browserify": "^16.3.0",
     "standard": "*",
-    "tape": "4.x"
+    "tape": "^5.4.0"
   },
   "homepage": "https://github.com/feross/base64-js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "T. Jameson Little <t.jameson.little@gmail.com>",
   "typings": "index.d.ts",
   "bugs": {
-    "url": "https://github.com/beatgammit/base64-js/issues"
+    "url": "https://github.com/feross/base64-js/issues"
   },
   "devDependencies": {
     "babel-minify": "^0.5.1",
@@ -14,7 +14,7 @@
     "standard": "*",
     "tape": "4.x"
   },
-  "homepage": "https://github.com/beatgammit/base64-js",
+  "homepage": "https://github.com/feross/base64-js",
   "keywords": [
     "base64"
   ],
@@ -22,7 +22,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/beatgammit/base64-js.git"
+    "url": "git://github.com/feross/base64-js.git"
   },
   "scripts": {
     "build": "browserify -s base64js -r ./ | minify > base64js.min.js",


### PR DESCRIPTION
The `tape` dependency was outdated, this brings it to the latest version.